### PR TITLE
added public general use query function

### DIFF
--- a/DM_Matrix.php
+++ b/DM_Matrix.php
@@ -306,7 +306,7 @@ if (isset($_GET['schema'])) {
 				echo "<td>";
 				echo "<a href='load.php?id=DM_Matrix&action=matrix_manager&edit=".$schema."'>";
 				echo "<img src='../plugins/DM_Matrix/images/edit.png' title='".i18n_r($thisfile_DM_Matrix.'/DM_EDITTABLE')."' /></a>";
-				if (count($key['fields'])>1){
+				if (isset($key['fields']) and count($key['fields'])>1){
 					echo " <a href='load.php?id=DM_Matrix&action=matrix_manager&add=".$schema."'>";
 					echo "<img src='../plugins/DM_Matrix/images/add.png' title='".i18n_r($thisfile_DM_Matrix.'/DM_ADDRECORD')."' /></a>";
 				}

--- a/DM_Matrix.php
+++ b/DM_Matrix.php
@@ -295,18 +295,19 @@ if (isset($_GET['schema'])) {
 		<?php 
     $tables=0;    
 		foreach($schemaArray as $schema=>$key){
+			$fieldcnt = isset($key['fields']) ? count($key['fields']) : '0';
 			if (substr($schema,0,1)!="_"){
-				if (count($key['fields'])>1){
+				if ($fieldcnt > 1){
 					echo "<tr><td><a href='load.php?id=DM_Matrix&action=matrix_manager&view=".$schema."' >".$schema."</a></td>";
 				} else {
 					echo "<tr><td>".$schema."</td>";	
 				}
 				echo "<td>".($key['id'])." / ".$key['maxrecords']."</td>";
-				echo "<td>".count($key['fields'])."</td>";
+				echo "<td>".$fieldcnt."</td>";
 				echo "<td>";
 				echo "<a href='load.php?id=DM_Matrix&action=matrix_manager&edit=".$schema."'>";
 				echo "<img src='../plugins/DM_Matrix/images/edit.png' title='".i18n_r($thisfile_DM_Matrix.'/DM_EDITTABLE')."' /></a>";
-				if (isset($key['fields']) and count($key['fields'])>1){
+				if ($fieldcnt > 1){
 					echo " <a href='load.php?id=DM_Matrix&action=matrix_manager&add=".$schema."'>";
 					echo "<img src='../plugins/DM_Matrix/images/add.png' title='".i18n_r($thisfile_DM_Matrix.'/DM_ADDRECORD')."' /></a>";
 				}

--- a/DM_Matrix.php
+++ b/DM_Matrix.php
@@ -61,7 +61,7 @@ $uriRoutes=array();
 $sql = new sql4array();
 $mytable=array();
 
-
+$DM_tables_cache = array(); // hold cached schema loads
 
 // only load all our scripts and style if were on the MAtrix Plugin page
 if (isset($_GET['id']) && $_GET['id']=="DM_Matrix"){

--- a/DM_Matrix/include/DM_matrix_functions.php
+++ b/DM_Matrix/include/DM_matrix_functions.php
@@ -97,23 +97,25 @@ function DM_saveSchema(){
 		$pages->addChild('name',$table);
 		$pages->addChild('id',$key['id']);
 		$pages->addChild('maxrecords',$key['maxrecords']);
-		foreach($key['fields'] as $field=>$type){
-			//$options=$schemaArray[$table]['options'];
-
-			$field=$pages->addChild('field',$field);
-			$field->addAttribute('type',$type);
-			$field->addAttribute('tableview',@$schemaArray[$table]['tableview'][(string)$field]);
-			$field->addAttribute('cacheindex',@$schemaArray[$table]['cacheindex'][(string)$field]);
-			$field->addAttribute('description',@$schemaArray[$table]['desc'][(string)$field]);
-			$field->addAttribute('label',@$schemaArray[$table]['label'][(string)$field]);
-			
-			if ($type=='dropdown'){
-				$field->addAttribute('table',@$schemaArray[$table]['table'][(string)$field]);
-				$field->addAttribute('row',@$schemaArray[$table]['row'][(string)$field]);
-			}
-			
-		}
 		
+		if (isset($key['fields'])){		
+			foreach($key['fields'] as $field=>$type){
+				//$options=$schemaArray[$table]['options'];
+
+				$field=$pages->addChild('field',$field);
+				$field->addAttribute('type',$type);
+				$field->addAttribute('tableview',@$schemaArray[$table]['tableview'][(string)$field]);
+				$field->addAttribute('cacheindex',@$schemaArray[$table]['cacheindex'][(string)$field]);
+				$field->addAttribute('description',@$schemaArray[$table]['desc'][(string)$field]);
+				$field->addAttribute('label',@$schemaArray[$table]['label'][(string)$field]);
+				
+				if ($type=='dropdown'){
+					$field->addAttribute('table',@$schemaArray[$table]['table'][(string)$field]);
+					$field->addAttribute('row',@$schemaArray[$table]['row'][(string)$field]);
+				}
+				
+			}
+		}
 	}
 	$xml->asXML($file);
 	DM_getSchema(true);

--- a/DM_Matrix/include/DM_matrix_functions.php
+++ b/DM_Matrix/include/DM_matrix_functions.php
@@ -514,7 +514,7 @@ function displayFieldType($name, $type, $schema,$value=''){
 			echo '<p><select id="post-'.$name.'" name="post-'.$name.'">';
 			echo '<option value=""></option>';
 			foreach ($pagesArray as $page){
-				if ($page['url']==$value) $options=' selected ';
+				$page['url']==$value ? $options=' selected ' : $options='';
 				echo '<option value="'.$page['url'].'" '.$options.'>'.$page['title'].'</option>';
 			}
 			echo '</select></p>';

--- a/DM_Matrix/include/DM_matrix_functions.php
+++ b/DM_Matrix/include/DM_matrix_functions.php
@@ -599,6 +599,18 @@ function displayFieldType($name, $type, $schema,$value=''){
 	}
 }
 
+function DM_query($query,$cache=true){
+	$sql=new sql4array();
+	$sql->createFromGlobals(false);
+	$tables = $sql->get_tablenames($query);
+
+	foreach($tables as $table){
+		if(!isset($DM_tables_cache[$table]) or $cache==false) $DM_tables_cache[$table] = getSchemaTable($table);
+		$sql->asset($table,$DM_tables_cache[$table]);
+	}
+
+	return $sql->query($query);
+}
 
 function DMdebuglog($log){
 	global $DM_Matrix_debug;

--- a/DM_Matrix/include/DM_matrix_functions.php
+++ b/DM_Matrix/include/DM_matrix_functions.php
@@ -507,7 +507,7 @@ function displayFieldType($name, $type, $schema,$value=''){
 		// Checkbox
 		case "checkbox":
 			$label=$schemaArray[$schema]['label'][$name];
-			echo '<p><input id="post-'.$name.'" class="required" name="post-'.$name.'" type="checkbox" > '.$label.'</p>';
+			echo '<p><input id="post-'.$name.'" class="required" name="post-'.$name.'" type="checkbox" '. ($value=='on' ? 'checked' : '') .'> '.$label.'</p>';
 			break;
 		// Dropdown box of existing pages on the site. Values are skug/url 
 		case "pages":
@@ -533,7 +533,7 @@ function displayFieldType($name, $type, $schema,$value=''){
 			}			
 			sort($templates);	
 			foreach ($templates as $file){
-				if ($file==$value) $options=' selected ';
+				$file==$value ? $options=' selected ' : $options='';			
 				$theme_templates .= '<option value="'.$file.'" '.$options.'>'.$file.'</option>';
 			}
 			echo '<p><select  id="post-'.$name.'" name="post-'.$name.'">';

--- a/DM_Matrix/include/sql4array.php
+++ b/DM_Matrix/include/sql4array.php
@@ -554,6 +554,22 @@ class sql4array
 
 		return $return;
 	}
+	
+	public function get_tablenames($query){
+			$this->destroy();
+			$this->query = $query;
+
+			# if (!$this->cacheQueryGet($this->query))
+			# {
+
+				$this
+					->parse_query()
+					->parse_from()
+				;
+			# }
+			
+			return $this->parse_from;
+	}		
 }
 
 ?>


### PR DESCRIPTION
Added a single use query function.

Didn't know what to name it
so

DM_query($query,$cache=true)

will auto load tables needed into the class, and also save them to a global cache array after they are loaded from file. This way files are only loaded once. But you can provide the cache argument to override in case you know the table has changed.

I intend this to be used by end users, not plugin authors who are touching the actual data, they have their own logic level functions to work with the actual schema directly.

Nothing else is needed to do a simple query.

I added a public function to the sql4array class to parse out the tables in the query and return the names in an array. This this depends on , also added a global table cache array for read in tables for this to use.
